### PR TITLE
Make the contract abstract

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
-*.js
 *.lock
 pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Install with
 npm install @ndujalabs/wormhole-tunnel
 ```
 
+Most likely, you also have to explicit install the peer dependencies, like:
+``` 
+npm install @openzeppelin/contracts
+```
+or 
+``` 
+npm install @openzeppelin/contracts-upgradeable
+```
+
+## History
+
+**0.4.0**
+- make the contracts abstract to force the implementation of the two required functions.
+
 ## API
 
 coming soon...

--- a/contracts/WormholeTunnel.sol
+++ b/contracts/WormholeTunnel.sol
@@ -12,7 +12,7 @@ import "./interfaces/IWormholeTunnel.sol";
 
 import "hardhat/console.sol";
 
-contract WormholeTunnel is IWormholeTunnel, WormholeCommon, Ownable, Pausable, ERC165 {
+abstract contract WormholeTunnel is IWormholeTunnel, WormholeCommon, Ownable, Pausable, ERC165 {
   using BytesLib for bytes;
 
   function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
@@ -37,26 +37,24 @@ contract WormholeTunnel is IWormholeTunnel, WormholeCommon, Ownable, Pausable, E
     return contractByChainId(chainId);
   }
 
+  /** @dev Examples of implementation for an ERC721:
+
   function wormholeTransfer(
     uint256 payload,
     uint16 recipientChain,
     bytes32 recipient,
     uint32 nonce
   ) public payable virtual override whenNotPaused returns (uint64 sequence) {
-    // do something here, before launching the transfer
-    // For example, for an ERC721, where payload is the tokenId, you can burn the token on the starting chain:
-    //    require(owner(payload) == _msgSender(), "ERC721: transfer caller is not the owner");
-    //    _burn(payload);
+    require(owner(payload) == _msgSender(), "ERC721: transfer caller is not the owner");
+    _burn(payload);
     return _wormholeTransferWithValue(payload, recipientChain, recipient, nonce, msg.value);
   }
 
   // Complete a transfer from Wormhole
   function wormholeCompleteTransfer(bytes memory encodedVm) public virtual override {
-    // solhint-disable-next-line
     (address to, uint256 payload) = _wormholeCompleteTransfer(encodedVm);
-    // do something here, after receiving the transfer
-    // For example, with an ERC721, where payload is the tokenId,
-    // you mint a token on the receiving chain
-    //    _safeMint(to, payload);
+    _safeMint(to, payload);
   }
+
+  */
 }

--- a/contracts/WormholeTunnelUpgradeable.sol
+++ b/contracts/WormholeTunnelUpgradeable.sol
@@ -11,7 +11,7 @@ import "./libraries/BytesLib.sol";
 import "./WormholeCommon.sol";
 import "./interfaces/IWormholeTunnel.sol";
 
-contract WormholeTunnelUpgradeable is
+abstract contract WormholeTunnelUpgradeable is
   IWormholeTunnel,
   WormholeCommon,
   PausableUpgradeable,
@@ -47,28 +47,26 @@ contract WormholeTunnelUpgradeable is
     return contractByChainId(chainId);
   }
 
+  uint256[50] private __gap;
+
+  /** @dev Examples of implementation for an ERC721:
+
   function wormholeTransfer(
     uint256 payload,
     uint16 recipientChain,
     bytes32 recipient,
     uint32 nonce
   ) public payable virtual override whenNotPaused returns (uint64 sequence) {
-    // do something here, before launching the transfer
-    // For example, for an ERC721, where payload is the tokenId, you can burn the token on the starting chain:
-    //    require(owner(payload) == _msgSender(), "ERC721: transfer caller is not the owner");
-    //    _burn(payload);
+    require(owner(payload) == _msgSender(), "ERC721: transfer caller is not the owner");
+    _burn(payload);
     return _wormholeTransferWithValue(payload, recipientChain, recipient, nonce, msg.value);
   }
 
   // Complete a transfer from Wormhole
   function wormholeCompleteTransfer(bytes memory encodedVm) public virtual override {
-    // solhint-disable-next-line
     (address to, uint256 payload) = _wormholeCompleteTransfer(encodedVm);
-    // do something here, after receiving the transfer
-    // For example, with an ERC721, where payload is the tokenId,
-    // you mint a token on the receiving chain
-    //    _safeMint(to, payload);
+    _safeMint(to, payload);
   }
 
-  uint256[50] private __gap;
+  */
 }

--- a/contracts/WormholeTunnelUpgradeable.sol
+++ b/contracts/WormholeTunnelUpgradeable.sol
@@ -47,8 +47,6 @@ abstract contract WormholeTunnelUpgradeable is
     return contractByChainId(chainId);
   }
 
-  uint256[50] private __gap;
-
   /** @dev Examples of implementation for an ERC721:
 
   function wormholeTransfer(
@@ -69,4 +67,7 @@ abstract contract WormholeTunnelUpgradeable is
   }
 
   */
+
+  uint256[50] private __gap;
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/wormhole-tunnel",
-  "version": "0.3.5",
+  "version": "0.4.0-beta.0",
   "description": "An implementation of Wormhole native protocol for generic transfers",
   "publishConfig": {
     "access": "public"
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "npx hardhat test",
     "compile": "npx hardhat compile",
-    "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'"
+    "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'",
+    "format": "npx prettier --write 'test'/**/*.js"
   },
   "authors": [
     "Evan Gray <egray@jumptrading.com>",

--- a/test/WormholeTunnel.test.js
+++ b/test/WormholeTunnel.test.js
@@ -23,7 +23,6 @@ describe("#WormholeTunner", function () {
   });
 
   async function initAndDeploy() {
-
     wormhole = await WormholeMock.deploy();
     await wormhole.deployed();
 
@@ -40,7 +39,6 @@ describe("#WormholeTunner", function () {
 
     await bridgeableOnChain2.wormholeInit(4, wormhole.address);
     await bridgeableOnChain2.wormholeRegisterContract(2, bytes32Address(bridgeableOnChain1.address));
-
   }
 
   describe("integration test", async function () {
@@ -49,24 +47,17 @@ describe("#WormholeTunner", function () {
     });
 
     it("should manage the entire flow", async function () {
-      const tokenId = ethers.BigNumber.from('1')
-      await bridgeableOnChain1.mintNft(user1.address)
-      expect(await bridgeableOnChain1.ownerOf(1)).equal(user1.address)
+      const tokenId = ethers.BigNumber.from("1");
+      await bridgeableOnChain1.mintNft(user1.address);
+      expect(await bridgeableOnChain1.ownerOf(1)).equal(user1.address);
       await bridgeableOnChain1.connect(user1).wormholeTransfer(tokenId, 4, bytes32Address(user1.address), 1);
-      await assertThrowsMessage(
-          bridgeableOnChain1.ownerOf(1),
-          "ERC721: owner query for nonexistent token"
-      )
-      await assertThrowsMessage(
-          bridgeableOnChain2.ownerOf(1),
-         "ERC721: owner query for nonexistent token"
-      )
+      await assertThrowsMessage(bridgeableOnChain1.ownerOf(1), "ERC721: owner query for nonexistent token");
+      await assertThrowsMessage(bridgeableOnChain2.ownerOf(1), "ERC721: owner query for nonexistent token");
 
       const fakeEvm = await bridgeableOnChain1.getFakeEvm(user1.address, tokenId);
 
       await bridgeableOnChain2.wormholeCompleteTransfer(fakeEvm);
-      expect(await bridgeableOnChain2.ownerOf(1)).equal(user1.address)
-
+      expect(await bridgeableOnChain2.ownerOf(1)).equal(user1.address);
     });
   });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,74 +1,71 @@
 const {assert} = require("chai");
 
 const Helpers = {
-
   initEthers(ethers) {
-    this.ethers = ethers
+    this.ethers = ethers;
   },
 
   async assertThrowsMessage(promise, message) {
     try {
-      await promise
-      console.log('It did not throw :-(')
-      assert.isTrue(false)
+      await promise;
+      console.log("It did not throw :-(");
+      assert.isTrue(false);
     } catch (e) {
-      const shouldBeTrue = e.message.indexOf(message) > -1
+      const shouldBeTrue = e.message.indexOf(message) > -1;
       if (!shouldBeTrue) {
-        console.error('Expected:', message)
-        console.error('Returned:', e.message)
+        console.error("Expected:", message);
+        console.error("Returned:", e.message);
         // console.log(e)
       }
-      assert.isTrue(shouldBeTrue)
+      assert.isTrue(shouldBeTrue);
     }
   },
 
   async deployContractBy(contractName, owner, ...args) {
-    const Contract = await this.ethers.getContractFactory(contractName)
-    const contract = await Contract.connect(owner).deploy(...args)
-    await contract.deployed()
-    return contract
+    const Contract = await this.ethers.getContractFactory(contractName);
+    const contract = await Contract.connect(owner).deploy(...args);
+    await contract.deployed();
+    return contract;
   },
 
   async deployContract(contractName, ...args) {
-    const Contract = await this.ethers.getContractFactory(contractName)
-    const contract = await Contract.deploy(...args)
-    await contract.deployed()
-    return contract
+    const Contract = await this.ethers.getContractFactory(contractName);
+    const contract = await Contract.deploy(...args);
+    await contract.deployed();
+    return contract;
   },
 
   async deployContractUpgradeable(contractName, args) {
-    const Contract = await this.ethers.getContractFactory(contractName)
+    const Contract = await this.ethers.getContractFactory(contractName);
     const contract = await upgrades.deployProxy(Contract, args);
-    await contract.deployed()
-    return contract
+    await contract.deployed();
+    return contract;
   },
 
-
   async signPackedData(
-      hash,
-      // hardhat account #4, starting from #0
-      privateKey = '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
+    hash,
+    // hardhat account #4, starting from #0
+    privateKey = "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
   ) {
-    const signingKey = new this.ethers.utils.SigningKey(privateKey)
-    const signedDigest = signingKey.signDigest(hash)
-    return this.ethers.utils.joinSignature(signedDigest)
+    const signingKey = new this.ethers.utils.SigningKey(privateKey);
+    const signedDigest = signingKey.signDigest(hash);
+    return this.ethers.utils.joinSignature(signedDigest);
   },
 
   async getTimestamp() {
-    return (await this.ethers.provider.getBlock()).timestamp
+    return (await this.ethers.provider.getBlock()).timestamp;
   },
 
-  addr0: '0x0000000000000000000000000000000000000000',
+  addr0: "0x0000000000000000000000000000000000000000",
 
   async increaseBlockTimestampBy(offset) {
-    await this.ethers.provider.send("evm_increaseTime", [offset])
-    await this.ethers.provider.send('evm_mine')
+    await this.ethers.provider.send("evm_increaseTime", [offset]);
+    await this.ethers.provider.send("evm_mine");
   },
 
   bytes32Address(address) {
     return "0x000000000000000000000000" + address.replace(/^0x/, "");
   },
+};
 
-}
-
-module.exports = Helpers
+module.exports = Helpers;


### PR DESCRIPTION
Make the basic contract abstract to force the implementer to implement the required functions, and solve compilation warnings.